### PR TITLE
Unknown command line options

### DIFF
--- a/pd.sh
+++ b/pd.sh
@@ -71,10 +71,10 @@ shift 1
                 # Only continue if there is at least one argument after the option identifier
                 if [[ $# -gt 1 ]]; then
                     # The first argument after the option identifier is the ref name
-                    if [[ $2 != *"/"* ]]; then
+                    if [[ $2 != *"/"* && $2 != -* ]]; then
                         ref="$2"
                     else
-                        echo "ERROR: Reference name may not contain '/'"
+                        echo "ERROR: Reference name may not contain '/' or begin with '-'"
                         return 11
                     fi
 

--- a/pd.sh
+++ b/pd.sh
@@ -141,6 +141,10 @@ shift 1
                 echo -e "Park Directories version $PD_VERSION"
                 shift 1
                 ;;
+            -*|--*) # Catch any unknown arguments
+                echo "$1  ERROR: Unknown argument"
+                shift 1
+                ;;
             *)          # Positional argument
                 ref="$1"
                 # Change to the parked directory by name


### PR DESCRIPTION
* Treat all command line arguments that begin with `-` or `--` as command line options
* If the option is unrecognized, report it as such.
* Prevent ADD action from parking a directory with a reference name that begins with `-`

Closes #36 
