### PR TITLE
[Issue #41] - Report empty list of parked directories

### DIFF
--- a/pd.sh
+++ b/pd.sh
@@ -122,10 +122,15 @@ shift 1
                 fi
                 ;;
             -l|--list)  # List all of the bookmarked directories
-                # List all parked directories
-                echo
-                cat "$pdFile" || return 30
-                echo
+                # If the list is empty, tell the user.
+                if [[ $(wc -l "$pdFile" | cut -d' ' -f1) -eq 0 ]]; then
+                    echo "    No directories have been parked yet"
+                else
+                    # List all parked directories
+                    echo
+                    cat "$pdFile" || return 30
+                    echo
+                fi
                 shift 1
                 ;;
             -c|--clear) # Clear the entire list of bookmarked directories


### PR DESCRIPTION
Instead of showing three empty lines when the user executes pd -l
and the list is empty, display "No directories have been parked yet".

Closes #41 