### PR TITLE
Phase 6: document cargo install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,14 @@ your PATH:
 
 **Option 2 — Install with cargo**
 
+Requires [Rust](https://rustup.rs) (rustup is recommended).
+
 ```
 cargo install park-directories
 ```
+
+The binary is installed as `pd` in `~/.cargo/bin/`, which rustup adds to your
+PATH automatically. To update to the latest version, re-run the same command.
 
 **Option 3 — Build from source**
 
@@ -131,7 +136,8 @@ source ~/.config/nushell/pd.nu
 
 **Updating**
 
-When you update the `pd` binary, regenerate `pd.nu` to pick up any changes:
+Update the binary (if installed via cargo: `cargo install park-directories`),
+then regenerate `pd.nu` to pick up any shell integration changes:
 
 ```nushell
 pd init nu | save -f ~/.config/nushell/pd.nu
@@ -152,7 +158,8 @@ source ~/.bashrc
 
 **Updating**
 
-When you update the `pd` binary, restart your terminal or run:
+Update the binary (if installed via cargo: `cargo install park-directories`),
+then restart your terminal or run:
 
 ```bash
 eval "$(pd init bash)"
@@ -179,8 +186,8 @@ exist.
 
 **Updating**
 
-When you update the `pd` binary, restart your terminal or run `. $PROFILE` to
-re-evaluate the integration.
+Update the binary (if installed via cargo: `cargo install park-directories`),
+then restart your terminal or run `. $PROFILE` to re-evaluate the integration.
 
 ---
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -131,7 +131,7 @@ The binary generates the shell shim code, making installation self-contained.
 ### cargo install (crates.io)
 - [x] Verify crate name `pd` is available on crates.io; if not, use `park-directories` with `[[bin]] name = "pd"`
 - [x] Complete `Cargo.toml` metadata: `repository`, `keywords`, `categories`, `readme`
-- [ ] `cargo publish` after CI is in place and confirms clean cross-platform builds
+- [x] `cargo publish` after CI is in place and confirms clean cross-platform builds
 
 ---
 


### PR DESCRIPTION
## Summary

- Expands the `cargo install park-directories` option in the **Get the binary** section to explain that the binary lands in `~/.cargo/bin/pd` (added to PATH automatically by rustup) and that re-running the command updates the binary.
- Adds a `cargo install park-directories` update reminder to the **Updating** subsections for all three shells (nushell, bash, PowerShell).

## Test plan

- [x] Review README diff for accuracy and clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)