### PR TITLE
Simplify nushell setup to auto-regenerate on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,30 +118,33 @@ in your PATH.
 
 **Step 1 — [Get the binary](#get-the-binary)** (see above)
 
-**Step 2 — Generate the nushell integration file**
+**Step 2 — Add to your nushell config**
+
+Add these two lines to `~/.config/nushell/config.nu`:
 
 ```nushell
-pd init nu | save -f ~/.config/nushell/pd.nu
-```
-
-**Step 3 — Source it in your nushell config**
-
-Add the following line to `~/.config/nushell/config.nu`:
-
-```nushell
+^pd init nu | save -f ~/.config/nushell/pd.nu
 source ~/.config/nushell/pd.nu
 ```
 
-**Step 4 — Restart your terminal** (or run `source ~/.config/nushell/config.nu`)
+The first line regenerates the integration script from the binary on every
+shell startup, so the integration stays in sync automatically whenever you
+update `pd`. You can store `pd.nu` anywhere you like — just use the same path
+in both lines.
+
+> **Note:** `~/.config/nushell/` does not exist by default. Before adding
+> these lines, either create the directory (`mkdir ~/.config/nushell`) or
+> choose a directory that already exists and adjust the path accordingly.
+> `config.nu` itself is typically found at the path reported by
+> `$nu.config-path`.
+
+**Step 3 — Restart your terminal**
 
 **Updating**
 
 Update the binary (if installed via cargo: `cargo install park-directories`),
-then regenerate `pd.nu` to pick up any shell integration changes:
-
-```nushell
-pd init nu | save -f ~/.config/nushell/pd.nu
-```
+then restart your terminal. The integration script regenerates automatically
+on startup — no additional steps required.
 
 ---
 


### PR DESCRIPTION
## Summary

Replaces the four-step nushell setup with a two-line `config.nu` approach that keeps the integration script automatically in sync with the binary.

**Before:** generate file manually → add `source` line → restart → remember to re-run `pd init nu` after every binary update

**After:** add two lines to `config.nu` → restart → updates are automatic forever

The two lines added to `config.nu`:
```nushell
^pd init nu | save -f ~/.config/nushell/pd.nu
source ~/.config/nushell/pd.nu
```

Also adds a note that `~/.config/nushell/` does not exist by default and directs users to either create it or choose an existing directory, with `$nu.config-path` as the way to locate `config.nu`.

## Test plan

- [x] On a fresh nushell setup, adding the two lines and restarting produces a working `pd` command
- [x] After updating the `pd` binary, restarting the terminal automatically picks up the new integration script with no manual steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)