### PR TITLE
Fix nushell setup: split save-f into env.nu, source into config.nu

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,23 +120,30 @@ in your PATH.
 
 **Step 2 — Add to your nushell config**
 
-Add these two lines to `~/.config/nushell/config.nu`:
+Add one line to `~/.config/nushell/env.nu`:
 
 ```nushell
 ^pd init nu | save -f ~/.config/nushell/pd.nu
+```
+
+Then add one line to `~/.config/nushell/config.nu`:
+
+```nushell
 source ~/.config/nushell/pd.nu
 ```
 
-The first line regenerates the integration script from the binary on every
-shell startup, so the integration stays in sync automatically whenever you
-update `pd`. You can store `pd.nu` anywhere you like — just use the same path
-in both lines.
+These two lines must live in **different files**. Nushell resolves `source`
+at parse time, before any code in `config.nu` runs. Putting the `save -f` in
+`env.nu` ensures `pd.nu` exists on disk by the time `config.nu` is parsed —
+whether this is the very first run or after a `pd` upgrade.
+
+You can store `pd.nu` anywhere you like — just use the same path in both lines.
 
 > **Note:** `~/.config/nushell/` does not exist by default. Before adding
 > these lines, either create the directory (`mkdir ~/.config/nushell`) or
 > choose a directory that already exists and adjust the path accordingly.
-> `config.nu` itself is typically found at the path reported by
-> `$nu.config-path`.
+> `env.nu` and `config.nu` are typically found at the paths reported by
+> `$nu.env-path` and `$nu.config-path`.
 
 **Step 3 — Restart your terminal**
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -234,11 +234,11 @@ complete -o nospace -F _pd_completions pd
 // ─── Nushell ─────────────────────────────────────────────────────────────────
 
 /// Full nushell integration: navigation command + tab completion.
-/// Generate with: pd init nu | save -f ~/.config/nushell/pd.nu
-/// Source in config.nu with: source ~/.config/nushell/pd.nu
+/// Add to env.nu:    ^pd init nu | save -f ~/.config/nushell/pd.nu
+/// Add to config.nu: source ~/.config/nushell/pd.nu
 const NU_INIT: &str = r#"# Park Directories — nushell integration
-# Generate this file with:
-#   pd init nu | save -f ~/.config/nushell/pd.nu
+# Add to ~/.config/nushell/env.nu:
+#   ^pd init nu | save -f ~/.config/nushell/pd.nu
 # Add to ~/.config/nushell/config.nu:
 #   source ~/.config/nushell/pd.nu
 


### PR DESCRIPTION
Closes #71

## Summary

- Moves `^pd init nu | save -f ~/.config/nushell/pd.nu` to `env.nu`
- Keeps `source ~/.config/nushell/pd.nu` in `config.nu`
- Updates the explanation in the README to describe why the split is required
- Updates the `$nu.config-path` note to also reference `$nu.env-path`
- Updates the comment header in `NU_INIT` (`src/init.rs`) to match

## Why

Nushell resolves `source` at **parse time**, before any code in `config.nu` executes. With both lines in `config.nu`, a fresh install fails immediately because `pd.nu` does not yet exist when nushell parses the file. Putting the `save -f` in `env.nu` (which is fully executed before `config.nu` is parsed) guarantees `pd.nu` is on disk in time — on first run and after every upgrade.

## Test plan

- [x] Fresh nushell install (no `pd.nu` present): confirm no parse error on startup and `pd` works
- [x] After a `pd` binary upgrade: confirm updated integration is active after a single restart
- [x] Existing setup with both lines in `config.nu`: follow updated instructions and verify correct behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)