### PR TITLE
Bump version to 3.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "park-directories"
-version = "3.2.0"
+version = "3.3.0"
 edition = "2021"
 description = "Park Directories — directory bookmarks for your terminal"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

Bumps `Cargo.toml` version from `3.2.0` to `3.3.0` to reflect the behavioral changes landed in #72 and #73 (nushell tab completion fixes and PowerShell completion documentation).

## Test plan

- [x] `pd --version` reports `3.3.0` after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)