### PR TITLE
Update release workflow actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     name: Test — Windows x64
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test
@@ -22,7 +22,7 @@ jobs:
     name: Test — Linux x64 (musl)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-unknown-linux-musl
@@ -34,7 +34,7 @@ jobs:
     name: Build — Linux ARM64 (musl)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-unknown-linux-musl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
             use_cross: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -72,7 +72,7 @@ jobs:
         shell: bash
         run: cp "target/${{ matrix.target }}/release/${{ matrix.binary }}" "${{ matrix.asset }}"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.asset }}
           path: ${{ matrix.asset }}
@@ -84,7 +84,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
           sha256sum pd-* > checksums.sha256
           cat checksums.sha256
 
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: |


### PR DESCRIPTION
## Summary

Updates all GitHub Actions running on the deprecated Node.js 20 runtime to Node.js 24-compatible versions:

| Workflow | Action | Before | After |
|---|---|---|---|
| release | `actions/checkout` | `v4` | `v6` |
| release | `actions/upload-artifact` | `v4` | `v7` |
| release | `actions/download-artifact` | `v4` | `v8` |
| release | `softprops/action-gh-release` | `v2` | `v3` |
| ci | `actions/checkout` | `v4` | `v6` (all 3 jobs) |

`download-artifact@v8` is confirmed compatible with `upload-artifact@v7` (and v4+).

## Why

GitHub Actions will force Node.js 24 as the default starting June 2, 2026, and will remove Node.js 20 from runners on September 16, 2026. The updated action versions ship with Node.js 24 support.

## Test plan

- [x] Pushed test tag `v3.3.1` — all build matrix jobs and the release job completed without deprecation warnings
- [x] Test release and tag deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)